### PR TITLE
[Bugfix] #22: Emails did not contain confirmation and activation links

### DIFF
--- a/Classes/Controller/FeuserCreateController.php
+++ b/Classes/Controller/FeuserCreateController.php
@@ -215,11 +215,15 @@ class FeuserCreateController extends FeuserController
 
                 $this->userRepository->update($user);
 
-                $this->sendEmails($user, 'PostCreateConfirm');
+                if ($this->settings['acceptEmailPostCreate']) {
+                    $this->sendEmails($user, 'PostCreateAccept');
+                } else {
+                    $this->sendEmails($user, 'PostCreateSave');
 
-                if ($this->settings['autologinPostConfirmation']) {
-                    $this->persistAll();
-                    $this->autoLogin($user);
+                    if ($this->settings['autologinPostConfirmation']) {
+                        $this->persistAll();
+                        $this->autoLogin($user);
+                    }
                 }
 
                 if ($this->settings['redirectPostActivationPageId']) {
@@ -295,7 +299,7 @@ class FeuserCreateController extends FeuserController
 
                 $this->userRepository->update($user);
 
-                $this->sendEmails($user, 'PostCreateAccept');
+                $this->sendEmails($user, 'PostCreateSave');
 
                 $this->view->assign('userAccepted', 1);
             }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -546,21 +546,21 @@
 				<source>dear admin</source>
 				<target>Sehr geehrter Admin</target>
 			</trans-unit>
-			<trans-unit id="email_admin_activate_message" xml:space="preserve" approved="yes">
-				<source>please activate the account %1$s</source>
-				<target>bitte aktivieren Sie den Accont %1$s</target>
-			</trans-unit>
 			<trans-unit id="email_admin_activate_link" xml:space="preserve" approved="yes">
 				<source>activate user account</source>
 				<target>Nutzer Account aktivieren</target>
 			</trans-unit>
-			<trans-unit id="email_admin_account_available" xml:space="preserve" approved="yes">
-				<source>the account %1$s is available</source>
-				<target>Account %1$s ist verfügbar</target>
+			<trans-unit id="email_admin_account_active" xml:space="preserve">
+				<source>The account "%1$s" is active.</source>
+				<target>Der Benutzeraccount "%1$s" ist aktiv.</target>
 			</trans-unit>
-			<trans-unit id="email_admin_account_activated" xml:space="preserve" approved="yes">
-				<source>the account %1$s was activated</source>
-				<target>Account %1$s wurde aktiviert</target>
+			<trans-unit id="email_admin_account_confirm" xml:space="preserve">
+				<source>The account "%1$s" has been created. The email needs to be confirmed by the user.</source>
+				<target>Der Benutzeraccount "%1$s" wurde erstellt. Die Email-Adresse muss vom Benutzer bestätigt werden.</target>
+			</trans-unit>
+			<trans-unit id="email_admin_account_accept" xml:space="preserve">
+				<source>The account "%1$s" needs to be accepted.</source>
+				<target>Der Benutzeraccount "%1$s" muss akzeptiert werden.</target>
 			</trans-unit>
 			<trans-unit id="email_admin_account_edited" xml:space="preserve" approved="yes">
 				<source>the account %1$s was edited</source>
@@ -570,21 +570,21 @@
 				<source>dear user</source>
 				<target>Sehr geehrter Nutzer</target>
 			</trans-unit>
-			<trans-unit id="email_user_activate_message" xml:space="preserve" approved="yes">
-				<source>please activate your account %1$s</source>
-				<target>bitte aktivierren Sie Ihren Account %1$s</target>
-			</trans-unit>
 			<trans-unit id="email_user_activate_link" xml:space="preserve" approved="yes">
 				<source>activate your account</source>
 				<target>aktivieren Ihres Accounts</target>
 			</trans-unit>
-			<trans-unit id="email_user_account_available" xml:space="preserve" approved="yes">
-				<source>your account %1$s is now available</source>
-				<target>Ihr Account %1$s ist jetzt verfügbar</target>
+			<trans-unit id="email_user_account_active" xml:space="preserve">
+				<source>Your account "%1$s" is active.</source>
+				<target>Ihr Benutzeraccount "%1s" ist aktiv.</target>
 			</trans-unit>
-			<trans-unit id="email_user_account_activated" xml:space="preserve" approved="yes">
-				<source>your account %1$s is now active</source>
-				<target>Ihr Account %1$s ist jetzt aktiv</target>
+			<trans-unit id="email_user_account_confirm" xml:space="preserve">
+				<source>Your account "%1$s" has been created. The email needs to be confirmed.</source>
+				<target>Ihr Benutzeraccount "%1$s" wurde erstellt. Die Email-Adresse muss bestätigt werden.</target>
+			</trans-unit>
+			<trans-unit id="email_user_account_accept" xml:space="preserve">
+				<source>Your account "%1$s" needs to be activated by the admin.</source>
+				<target>Ihr Benutzeraccount "%1$s" muss vom Administrator aktiviert werden.</target>
 			</trans-unit>
 			<trans-unit id="email_user_account_edited" xml:space="preserve" approved="yes">
 				<source>you have edited your account %1$s</source>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -522,21 +522,21 @@
 				<source>dear admin</source>
 				<target>cher admin</target>
 			</trans-unit>
-			<trans-unit id="email_admin_activate_message" xml:space="preserve" approved="yes">
-				<source>please activate the account %1$s</source>
-				<target>s'il-vous-plaît activez le compte %1$s</target>
-			</trans-unit>
 			<trans-unit id="email_admin_activate_link" xml:space="preserve" approved="yes">
 				<source>activate user account</source>
 				<target>activation du compte utilisateur</target>
 			</trans-unit>
-			<trans-unit id="email_admin_account_available" xml:space="preserve" approved="yes">
-				<source>the account %1$s is available</source>
-				<target>le compte %1$s est disponible</target>
+			<trans-unit id="email_admin_account_active" xml:space="preserve">
+				<source>The account "%1$s" is active.</source>
+				<target>Le compte "%1$s" est actif.</target>
 			</trans-unit>
-			<trans-unit id="email_admin_account_activated" xml:space="preserve" approved="yes">
-				<source>the account %1$s was activated</source>
-				<target>le compte %1$s a été activé</target>
+			<trans-unit id="email_admin_account_confirm" xml:space="preserve">
+				<source>The account "%1$s" has been created. The email needs to be confirmed by the user.</source>
+				<target>Le compte "%1$s" a été créé. L'email doit être confirmée par l'utilisateur.</target>
+			</trans-unit>
+			<trans-unit id="email_admin_account_accept" xml:space="preserve">
+				<source>The account "%1$s" needs to be accepted.</source>
+				<target>Le compte "%1$s" doit être accepté.</target>
 			</trans-unit>
 			<trans-unit id="email_admin_account_edited" xml:space="preserve" approved="yes">
 				<source>the account %1$s was edited</source>
@@ -546,21 +546,21 @@
 				<source>dear user</source>
 				<target>cher utilisateur</target>
 			</trans-unit>
-			<trans-unit id="email_user_activate_message" xml:space="preserve" approved="yes">
-				<source>please activate your account %1$s</source>
-				<target>s'il-vous-plaît activez votre compte %1$s</target>
-			</trans-unit>
 			<trans-unit id="email_user_activate_link" xml:space="preserve" approved="yes">
 				<source>activate your account</source>
 				<target>activer votre compte</target>
 			</trans-unit>
-			<trans-unit id="email_user_account_available" xml:space="preserve" approved="yes">
-				<source>your account %1$s is now available</source>
-				<target>votre compte %1$s est maitenant disponible</target>
+			<trans-unit id="email_user_account_active" xml:space="preserve">
+				<source>Your account "%1$s" is active.</source>
+				<target>Votre compte "%1$s" est actif.</target>
 			</trans-unit>
-			<trans-unit id="email_user_account_activated" xml:space="preserve" approved="yes">
-				<source>your account %1$s is now active</source>
-				<target>votre compte %1$s est maintenant activé</target>
+			<trans-unit id="email_user_account_confirm" xml:space="preserve">
+				<source>Your account "%1$s" has been created. The email needs to be confirmed.</source>
+				<target>Votre compte "%1$s" a été créé. L'email doit être confirmée.</target>
+			</trans-unit>
+			<trans-unit id="email_user_account_accept" xml:space="preserve">
+				<source>Your account "%1$s" needs to be activated by the admin.</source>
+				<target>Votre compte "%1$s" doit être activée par l'administrateur.</target>
 			</trans-unit>
 			<trans-unit id="email_user_account_edited" xml:space="preserve" approved="yes">
 				<source>you have edited your account %1$s</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -412,17 +412,17 @@
 			<trans-unit id="email_admin_salutation" xml:space="preserve">
 				<source>Dear admin</source>
 			</trans-unit>
-			<trans-unit id="email_admin_activate_message" xml:space="preserve">
-				<source>A new account "%1$s" has been requested and you need to activate it.</source>
-			</trans-unit>
 			<trans-unit id="email_admin_activate_link" xml:space="preserve">
 				<source>Activate user account</source>
 			</trans-unit>
-			<trans-unit id="email_admin_account_available" xml:space="preserve">
-				<source>The account "%1$s" is available</source>
+			<trans-unit id="email_admin_account_active" xml:space="preserve">
+				<source>The account "%1$s" is active.</source>
 			</trans-unit>
-			<trans-unit id="email_admin_account_activated" xml:space="preserve">
-				<source>The account "%1$s" was activated</source>
+			<trans-unit id="email_admin_account_confirm" xml:space="preserve">
+				<source>The account "%1$s" has been created. The email needs to be confirmed by the user.</source>
+			</trans-unit>
+			<trans-unit id="email_admin_account_accept" xml:space="preserve">
+				<source>The account "%1$s" needs to be accepted.</source>
 			</trans-unit>
 			<trans-unit id="email_admin_account_edited" xml:space="preserve">
 				<source>The account "%1$s" was edited</source>
@@ -430,17 +430,17 @@
 			<trans-unit id="email_user_salutation" xml:space="preserve">
 				<source>Dear user</source>
 			</trans-unit>
-			<trans-unit id="email_user_activate_message" xml:space="preserve">
-				<source>Your account "%1$s" has been created but needs to be activated.</source>
-			</trans-unit>
 			<trans-unit id="email_user_activate_link" xml:space="preserve">
 				<source>Activate your account</source>
 			</trans-unit>
-			<trans-unit id="email_user_account_available" xml:space="preserve">
-				<source>Your account "%1$s" is now available.</source>
+			<trans-unit id="email_user_account_active" xml:space="preserve">
+				<source>Your account "%1$s" is active.</source>
 			</trans-unit>
-			<trans-unit id="email_user_account_activated" xml:space="preserve">
-				<source>Your account "%1$s" is now active.</source>
+			<trans-unit id="email_user_account_confirm" xml:space="preserve">
+				<source>Your account "%1$s" has been created. The email needs to be confirmed.</source>
+			</trans-unit>
+			<trans-unit id="email_user_account_accept" xml:space="preserve">
+				<source>Your account "%1$s" needs to be activated by the admin.</source>
 			</trans-unit>
 			<trans-unit id="email_user_account_edited" xml:space="preserve">
 				<source>You have edited your account "%1$s".</source>

--- a/Resources/Private/Language/nl.locallang.xlf
+++ b/Resources/Private/Language/nl.locallang.xlf
@@ -479,21 +479,21 @@
 				<source>dear admin</source>
 				<target>beste admin</target>
 			</trans-unit>
-			<trans-unit id="email_admin_activate_message" xml:space="preserve" approved="yes">
-				<source>please activate the account %1$s</source>
-				<target>activeer account %1$s a.u.b.</target>
-			</trans-unit>
 			<trans-unit id="email_admin_activate_link" xml:space="preserve" approved="yes">
 				<source>activate user account</source>
 				<target>activeer gebruikers account</target>
 			</trans-unit>
-			<trans-unit id="email_admin_account_available" xml:space="preserve" approved="yes">
-				<source>the account %1$s is available</source>
-				<target>het account %1$s is beschikbaar</target>
+			<trans-unit id="email_admin_account_active" xml:space="preserve">
+				<source>The account "%1$s" is active.</source>
+				<target>De account "%1$s" actief is.</target>
 			</trans-unit>
-			<trans-unit id="email_admin_account_activated" xml:space="preserve" approved="yes">
-				<source>the account %1$s was activated</source>
-				<target>het account %1$s is geactiveerd</target>
+			<trans-unit id="email_admin_account_confirm" xml:space="preserve">
+				<source>The account "%1$s" has been created. The email needs to be confirmed by the user.</source>
+				<target>De account "%1$s" is aangemaakt. E dient te worden bevestigd door de gebruiker.</target>
+			</trans-unit>
+			<trans-unit id="email_admin_account_accept" xml:space="preserve">
+				<source>The account "%1$s" needs to be accepted.</source>
+				<target>De account "%1$s" moet worden aanvaard.</target>
 			</trans-unit>
 			<trans-unit id="email_admin_account_edited" xml:space="preserve" approved="yes">
 				<source>the account %1$s was edited</source>
@@ -503,21 +503,21 @@
 				<source>dear user</source>
 				<target>beste gebruiker</target>
 			</trans-unit>
-			<trans-unit id="email_user_activate_message" xml:space="preserve" approved="yes">
-				<source>please activate your account %1$s</source>
-				<target>activeer je account %1$s a.u.b.</target>
-			</trans-unit>
 			<trans-unit id="email_user_activate_link" xml:space="preserve" approved="yes">
 				<source>activate your account</source>
 				<target>activeer je account</target>
 			</trans-unit>
-			<trans-unit id="email_user_account_available" xml:space="preserve" approved="yes">
-				<source>your account %1$s is now available</source>
-				<target>je account %1$s is nu beschikbaar</target>
+			<trans-unit id="email_user_account_active" xml:space="preserve">
+				<source>Your account "%1$s" is active.</source>
+				<target>Je account "%1$s" actief is.</target>
 			</trans-unit>
-			<trans-unit id="email_user_account_activated" xml:space="preserve" approved="yes">
-				<source>your account %1$s is now active</source>
-				<target>je account %1$s is nu actief</target>
+			<trans-unit id="email_user_account_confirm" xml:space="preserve">
+				<source>Your account "%1$s" has been created. The email needs to be confirmed.</source>
+				<target>Je account "%1$s" is aangemaakt. E dient te worden bevestigd.</target>
+			</trans-unit>
+			<trans-unit id="email_user_account_accept" xml:space="preserve">
+				<source>Your account "%1$s" needs to be activated by the admin.</source>
+				<target>Je account "%1$s" moet worden geactiveerd door de admin.</target>
 			</trans-unit>
 			<trans-unit id="email_user_account_edited" xml:space="preserve" approved="yes">
 				<source>you have edited your account %1$s</source>

--- a/Resources/Private/Templates/Email/AdminNotificationPostCreateAccept.html
+++ b/Resources/Private/Templates/Email/AdminNotificationPostCreateAccept.html
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:register="http://typo3.org/ns/Evoweb/SfRegister/ViewHelpers">
 <head>
 	<title>Admin notification mail post create accept template of registration</title>
 </head>
 <body>
 <f:layout name="Email" />
 <f:section name="Main">
-<f:translate key="email_admin_salutation" htmlEscape="false"/>,
+	<f:translate key="email_admin_salutation" htmlEscape="false"/>,<br><br>
 
-<f:translate key="email_admin_account_available" arguments="{0: user.username}" htmlEscape="false"/>
+	<f:translate key="email_admin_account_accept" arguments="{0: user.username}" htmlEscape="false"/><br><br>
+
+	<register:link.action arguments="{user: user.uid}" action="accept" absolute="true" noCacheHash="true"><f:translate key="email_admin_activate_link" htmlEscape="false"/></register:link.action>
 </f:section>
 </body>
 </html>

--- a/Resources/Private/Templates/Email/AdminNotificationPostCreateConfirm.html
+++ b/Resources/Private/Templates/Email/AdminNotificationPostCreateConfirm.html
@@ -1,8 +1,6 @@
-{namespace register=Evoweb\SfRegister\ViewHelpers}
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:register="http://www.evoweb.de/ns/SfRegister/ViewHelpers">
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
 <head>
 	<title>Admin notification mail post create confirmation template of registration</title>
 </head>
@@ -11,9 +9,7 @@
 <f:section name="Main">
 <f:translate key="email_admin_salutation" htmlEscape="false"/>,
 
-<f:translate key="email_admin_account_activated" arguments="{0: user.username}" htmlEscape="false"/>
-
-<register:link.action arguments="{user: user.uid}" action="accept" absolute="true" noCacheHash="true"><f:translate key="email_admin_activate_link" htmlEscape="false"/></register:link.action>
+<f:translate key="email_admin_account_confirm" arguments="{0: user.username}" htmlEscape="false"/>
 </f:section>
 </body>
 </html>

--- a/Resources/Private/Templates/Email/AdminNotificationPostCreateSave.html
+++ b/Resources/Private/Templates/Email/AdminNotificationPostCreateSave.html
@@ -1,8 +1,6 @@
-{namespace register=Evoweb\SfRegister\ViewHelpers}
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:register="http://www.evoweb.de/ns/SfRegister/ViewHelpers">
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
 <head>
 	<title>Admin notification mail post create save template of registration</title>
 </head>
@@ -11,9 +9,7 @@
 <f:section name="Main">
 <f:translate key="email_admin_salutation" htmlEscape="false"/>,
 
-<f:translate key="email_admin_activate_message" arguments="{0: user.username}" htmlEscape="false"/>
-
-<register:link.action arguments="{user: user.uid}" action="accept" absolute="true" noCacheHash="true"><f:translate key="email_admin_activate_link" htmlEscape="false"/></register:link.action>
+<f:translate key="email_admin_account_active" arguments="{0: user.username}" htmlEscape="false"/>
 </f:section>
 </body>
 </html>

--- a/Resources/Private/Templates/Email/UserNotificationPostCreateAccept.html
+++ b/Resources/Private/Templates/Email/UserNotificationPostCreateAccept.html
@@ -9,7 +9,7 @@
 <f:section name="Main">
 <f:translate key="email_user_salutation" htmlEscape="false"/>,
 
-<f:translate key="email_user_account_available" arguments="{0: user.username}" htmlEscape="false"/>
+<f:translate key="email_user_account_accept" arguments="{0: user.username}" htmlEscape="false"/>
 </f:section>
 </body>
 </html>

--- a/Resources/Private/Templates/Email/UserNotificationPostCreateConfirm.html
+++ b/Resources/Private/Templates/Email/UserNotificationPostCreateConfirm.html
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	  xmlns:register="http://typo3.org/ns/Evoweb/SfRegister/ViewHelpers">
 <head>
 	<title>User notification mail post create confirm template of registration</title>
 </head>
 <body>
 <f:layout name="Email" />
 <f:section name="Main">
-<f:translate key="email_user_salutation" htmlEscape="false"/>,
+<f:translate key="email_user_salutation" htmlEscape="false"/>,<br><br>
 
-<f:translate key="email_user_account_activated" arguments="{0: user.username}" htmlEscape="false"/>
+<f:translate key="email_user_account_confirm" arguments="{0: user.username}" htmlEscape="false"/><br><br>
+
+<register:link.action arguments="{user: user.uid}" action="confirm" absolute="true" noCacheHash="true"><f:translate key="email_user_activate_link" htmlEscape="false"/></register:link.action>
 </f:section>
 </body>
 </html>

--- a/Resources/Private/Templates/Email/UserNotificationPostCreateSave.html
+++ b/Resources/Private/Templates/Email/UserNotificationPostCreateSave.html
@@ -1,19 +1,15 @@
-{namespace register=Evoweb\SfRegister\ViewHelpers}
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
-	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
-	  xmlns:register="http://www.evoweb.de/ns/SfRegister/ViewHelpers">
+	  xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers">
 <head>
 	<title>User notification mail post create save template of registration</title>
 </head>
 <body>
 <f:layout name="Email" />
 <f:section name="Main">
-<f:translate key="email_user_salutation" htmlEscape="false"/>,
+	<f:translate key="email_user_salutation" htmlEscape="false"/>,
 
-<f:translate key="email_user_activate_message" arguments="{0: user.username}" htmlEscape="false"/>
-
-<register:link.action arguments="{user: user.uid}" action="confirm" absolute="true" noCacheHash="true"><f:translate key="email_user_activate_link" htmlEscape="false"/></register:link.action>
+	<f:translate key="email_user_account_active" arguments="{0: user.username}" htmlEscape="false"/>
 </f:section>
 </body>
 </html>


### PR DESCRIPTION
see https://github.com/evoWeb/sf_register/pull/23
Previous PR was closed by the extension author, so I had to create a new one.
Also I would appreciate it if issues would not get closed without waiting for a response by the author. In my opinion it is a serious issue with the extension, when user accounts cannot be activated because the link in the email is simply missing.

The previous PR indeed does solve the problem that user accounts cannot be activated at all (because previously, there were no activation links in the emails when they were required -> Seems like an untested feature to me, tbh).
But because setting different types that resemble the notification that already contains the links makes it more confusing, now the notifications themselves are corrected here. That should make it all clear.
Also I adapted the translation keys and texts. Here I need some review about the french and dutch translations.

If you think, there is still missing something in this patch I would appreciate it if you would not close the PR, so I can change it, instead of create a new one. 
