### PR TITLE
TYPO3 8.7 fails to get configurations when extension- and pluginname …

### DIFF
--- a/Classes/Validation/Validator/UserValidator.php
+++ b/Classes/Validation/Validator/UserValidator.php
@@ -113,13 +113,17 @@ class UserValidator extends GenericObjectValidator implements ValidatorInterface
     public function injectConfigurationManager(
         \TYPO3\CMS\Extbase\Configuration\ConfigurationManager $configurationManager
     ) {
+
+        /** @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManager configurationManager */
         $this->configurationManager = $configurationManager;
         $this->settings = $this->configurationManager->getConfiguration(
-            \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS
+            \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS, 'SfRegister', 'Form'
         );
+
         $this->frameworkConfiguration = $this->configurationManager->getConfiguration(
-            \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
+            \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'SfRegister', 'Form'
         );
+
     }
 
     /**


### PR DESCRIPTION
…are not specified in validators