### PR TITLE
moving TS configuration file inclusion to TCA/Overrides

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,25 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+call_user_func(function () {
+    /** @noinspection PhpUndefinedVariableInspection */
+    $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['sf_register']);
+
+    switch ($extensionConfiguration['typoscriptComplexity']) {
+        case 'maximal':
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+                'sf_register',
+                'Configuration/TypoScript/maximal/',
+                'Feuser Register [maximal]'
+            );
+            break;
+        case 'minimal':
+            // fall through intended
+        default:
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+                'sf_register',
+                'Configuration/TypoScript/minimal/',
+                'Feuser Register [minimal]'
+            );
+    }
+});

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -4,28 +4,6 @@ defined('TYPO3_MODE') or die();
 call_user_func(
     function ($extKey) {
 
-    /** @noinspection PhpUndefinedVariableInspection */
-    $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$extKey]);
-
-    switch ($extensionConfiguration['typoscriptComplexity']) {
-        case 'maximal':
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-                $extKey,
-                'Configuration/TypoScript/maximal/',
-                'Feuser Register [maximal]'
-            );
-            break;
-        case 'minimal':
-            // fall through intended
-        default:
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-                $extKey,
-                'Configuration/TypoScript/minimal/',
-                'Feuser Register [minimal]'
-            );
-    }
-
-
     /**
      * Page TypoScript for mod wizards
      */


### PR DESCRIPTION
moving TS configuration file inclusion to TCA/Overrides since otherwise not visible in backend sys_template record; replacing $extKey with name of extension since not working in override files