### PR TITLE
[BUGFIX] Support AbstractTagBasedViewHelper attributes

### DIFF
--- a/Classes/ViewHelpers/Form/RangeSelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/RangeSelectViewHelper.php
@@ -70,36 +70,7 @@ class RangeSelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectView
      */
     public function initializeArguments()
     {
-        $this->registerUniversalTagAttributes();
-        $this->registerArgument('name', 'string', 'Name of input tag');
-        $this->registerArgument('value', 'mixed', 'Value of input tag');
-        $this->registerTagAttribute('multiple', 'string', 'if set, multiple select field');
-        $this->registerTagAttribute('size', 'string', 'Size of input field');
-        $this->registerTagAttribute(
-            'disabled',
-            'string',
-            'Specifies that the input element should be disabled when the page loads'
-        );
-        $this->registerArgument(
-            'property',
-            'string',
-            'Name of Object Property. If used in conjunction with <f:form object="...">,
- "name" and "value" properties will be ignored.'
-        );
-        $this->registerArgument(
-            'selectAllByDefault',
-            'boolean',
-            'If specified options are selected if none was set before.',
-            false,
-            false
-        );
-        $this->registerArgument(
-            'errorClass',
-            'string',
-            'CSS class to set if there are errors for this view helper',
-            false,
-            'f3-form-error'
-        );
+        parent::initializeArguments();
         $this->registerArgument(
             'start',
             'int',

--- a/Classes/ViewHelpers/Form/SelectStaticCountriesViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectStaticCountriesViewHelper.php
@@ -55,17 +55,8 @@ class SelectStaticCountriesViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\
      */
     public function initializeArguments()
     {
-        $this->registerUniversalTagAttributes();
-        $this->registerTagAttribute('multiple', 'string', 'if set, multiple select field');
-        $this->registerTagAttribute('size', 'string', 'Size of input field');
-        $this->registerTagAttribute(
-            'disabled',
-            'string',
-            'Specifies that the input element should be disabled when the page loads'
-        );
-        $this->registerArgument('name', 'string', 'Name of input tag');
-        $this->registerArgument('value', 'mixed', 'Value of input tag');
-        $this->registerArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, true);
+        parent::initializeArguments();
+        $this->overrideArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, true);
         $this->registerArgument(
             'allowedCountries',
             'array',
@@ -73,39 +64,19 @@ class SelectStaticCountriesViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\
             false,
             []
         );
-        $this->registerArgument(
-            'property',
-            'string',
-            'Name of Object Property. If used in conjunction with <f:form object="...">,
-             "name" and "value" properties will be ignored.'
-        );
-        $this->registerArgument(
+        $this->overrideArgument(
             'optionValueField',
             'string',
             'If specified, will call the appropriate getter on each object to determine the value.',
             false,
             'cnIso2'
         );
-        $this->registerArgument(
+        $this->overrideArgument(
             'optionLabelField',
             'string',
             'If specified, will call the appropriate getter on each object to determine the label.',
             false,
             'cnOfficialNameEn'
-        );
-        $this->registerArgument(
-            'selectAllByDefault',
-            'boolean',
-            'If specified options are selected if none was set before.',
-            false,
-            false
-        );
-        $this->registerArgument(
-            'errorClass',
-            'string',
-            'CSS class to set if there are errors for this view helper',
-            false,
-            'f3-form-error'
         );
     }
 

--- a/Classes/ViewHelpers/Form/SelectStaticCountryZonesViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectStaticCountryZonesViewHelper.php
@@ -51,51 +51,22 @@ class SelectStaticCountryZonesViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Fo
      */
     public function initializeArguments()
     {
-        $this->registerUniversalTagAttributes();
-        $this->registerTagAttribute('multiple', 'string', 'if set, multiple select field');
-        $this->registerTagAttribute('size', 'string', 'Size of input field');
-        $this->registerTagAttribute(
-            'disabled',
-            'string',
-            'Specifies that the input element should be disabled when the page loads'
-        );
-        $this->registerArgument('name', 'string', 'Name of input tag');
-        $this->registerArgument('value', 'mixed', 'Value of input tag');
+        parent::initializeArguments();
         $this->registerArgument('parent', 'string', 'Parent of this zone');
-        $this->registerArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, true);
-        $this->registerArgument(
-            'property',
-            'string',
-            'Name of Object Property. If used in conjunction with <f:form object="...">,
-            "name" and "value" properties will be ignored.'
-        );
-        $this->registerArgument(
+        $this->overrideArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, true);
+        $this->overrideArgument(
             'optionValueField',
             'string',
             'If specified, will call the appropriate getter on each object to determine the value.',
             false,
             'uid'
         );
-        $this->registerArgument(
+        $this->overrideArgument(
             'optionLabelField',
             'string',
             'If specified, will call the appropriate getter on each object to determine the label.',
             false,
             'zn_name_local'
-        );
-        $this->registerArgument(
-            'selectAllByDefault',
-            'boolean',
-            'If specified options are selected if none was set before.',
-            false,
-            false
-        );
-        $this->registerArgument(
-            'errorClass',
-            'string',
-            'CSS class to set if there are errors for this view helper',
-            false,
-            'f3-form-error'
         );
     }
 

--- a/Classes/ViewHelpers/Form/SelectStaticLanguageViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectStaticLanguageViewHelper.php
@@ -51,17 +51,8 @@ class SelectStaticLanguageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\S
      */
     public function initializeArguments()
     {
-        $this->registerUniversalTagAttributes();
-        $this->registerTagAttribute('multiple', 'string', 'if set, multiple select field');
-        $this->registerTagAttribute('size', 'string', 'Size of input field');
-        $this->registerTagAttribute(
-            'disabled',
-            'string',
-            'Specifies that the input element should be disabled when the page loads'
-        );
-        $this->registerArgument('name', 'string', 'Name of input tag');
-        $this->registerArgument('value', 'mixed', 'Value of input tag');
-        $this->registerArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, true);
+        parent::initializeArguments();
+        $this->overrideArgument('sortByOptionLabel', 'boolean', 'If true, List will be sorted by label.', false, true);
         $this->registerArgument(
             'allowedLanguages',
             'array',
@@ -69,39 +60,19 @@ class SelectStaticLanguageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\S
             false,
             []
         );
-        $this->registerArgument(
-            'property',
-            'string',
-            'Name of Object Property. If used in conjunction with <f:form object="...">,
-            "name" and "value" properties will be ignored.'
-        );
-        $this->registerArgument(
+        $this->overrideArgument(
             'optionValueField',
             'string',
             'If specified, will call the appropriate getter on each object to determine the value.',
             false,
             'lgIso2'
         );
-        $this->registerArgument(
+        $this->overrideArgument(
             'optionLabelField',
             'string',
             'If specified, will call the appropriate getter on each object to determine the label.',
             false,
             'lgNameEn'
-        );
-        $this->registerArgument(
-            'selectAllByDefault',
-            'boolean',
-            'If specified options are selected if none was set before.',
-            false,
-            false
-        );
-        $this->registerArgument(
-            'errorClass',
-            'string',
-            'CSS class to set if there are errors for this view helper',
-            false,
-            'f3-form-error'
         );
     }
 


### PR DESCRIPTION
initializeArguments calls parent::initializeArguments() now
and the different attribute registrations are changed by
overrideArgument. Dupe registrations from parent classes
are removed.

Resolves: #57