### PR TITLE
Fix a possible bug in `getFollowingUserGroups`

### DIFF
--- a/Classes/Controller/FeuserController.php
+++ b/Classes/Controller/FeuserController.php
@@ -411,7 +411,7 @@ class FeuserController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
         $currentIndex = array_search((int) $currentUserGroup, $userGroups);
 
         $reducedUserGroups = [];
-        if ($currentUserGroup !== false && $currentUserGroup < count($userGroups)) {
+        if ($currentIndex !== false && $currentIndex < count($userGroups)) {
             $reducedUserGroups = array_slice($userGroups, $currentIndex);
         }
 


### PR DESCRIPTION
I don't fully know how `getFollowingUserGroups()` works, but I guess there is a error in the if statement.

At least since changing to PHP 7 `if ($currentUserGroup !== false)` does not make sense for me