### PR TITLE
Fix bug with incorrect return type of `getModuleSysDmailCategory()`

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -516,7 +516,7 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
         $this->moduleSysDmailCategory = $moduleSysDmailCategory;
     }
 
-    public function getModuleSysDmailCategory(): array
+    public function getModuleSysDmailCategory()
     {
         return $this->moduleSysDmailCategory;
     }

--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -516,6 +516,9 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
         $this->moduleSysDmailCategory = $moduleSysDmailCategory;
     }
 
+    /**
+     * @return array|null
+     */
     public function getModuleSysDmailCategory()
     {
         return $this->moduleSysDmailCategory;


### PR DESCRIPTION
The method's return type is most likely an `ObjectStorage` or `NULL`