### PR TITLE
[BUGFIX] Avoid current request paramaters at autologin

### DIFF
--- a/Classes/Controller/FeuserController.php
+++ b/Classes/Controller/FeuserController.php
@@ -371,9 +371,13 @@ class FeuserController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
      */
     protected function redirectToPage($pageId)
     {
+        $this->uriBuilder->reset();
         if ($this->autoLoginTriggered) {
             $statusField = $this->getTypoScriptFrontendController()->fe_user->formfield_permanent;
-            $this->uriBuilder->setAddQueryString('&' . $statusField . '=login');
+            $this->uriBuilder->setArguments([
+                'logintype' => 'login',
+                $statusField => 'login'
+            ]);
         }
 
         $url = $this->uriBuilder


### PR DESCRIPTION
The method `$this->uriBuilder->setAddQueryString` expects a boolean to respect current arguments to the request.
This can create uri's with double `id=X`.