### PR TITLE
Make "Date of Birth" editable when was 0 before

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -346,7 +346,7 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
         $this->prepareDateOfBirth();
     }
 
-    public function getDateOfBirthDay(): int
+    public function getDateOfBirthDay(): ?int
     {
         $result = null;
 
@@ -363,7 +363,7 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
         $this->prepareDateOfBirth();
     }
 
-    public function getDateOfBirthMonth(): int
+    public function getDateOfBirthMonth(): ?int
     {
         $result = null;
 
@@ -380,7 +380,7 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
         $this->prepareDateOfBirth();
     }
 
-    public function getDateOfBirthYear(): int
+    public function getDateOfBirthYear(): ?int
     {
         $result = null;
 


### PR DESCRIPTION
If the "Date of Birth" is 0 (because it was not enabled during the Create-Process), you'll run into the following Error:

Return value of Evoweb\SfRegister\Domain\Model\FrontendUser::getDateOfBirthDay() must be of the type integer, null returned

Adding nullable Types with a questionmark set in fornt of the type, this behaviour can be resovled in lines 349, 366 and 383