### PR TITLE
Update link to known problems

### DIFF
--- a/Documentation/KnownProblems/Index.rst
+++ b/Documentation/KnownProblems/Index.rst
@@ -6,11 +6,11 @@
 Known problems
 ==============
 
-- `http://forge.typo3.org/projects/extension-sf\_register/issues
-  <http://forge.typo3.org/projects/extension-sf_register/issues>`_
+- `https://github.com/evoweb/sf\_register/issues
+  <https://github.com/evoweb/sf_register/issues>`_
 
 To-Do list
 ==========
 
-- `http://forge.typo3.org/projects/extension-sf\_register/issues
-  <http://forge.typo3.org/projects/extension-sf_register/issues>`_
+- `https://github.com/evoweb/sf\_register/issues
+  <https://github.com/evoweb/sf_register/issues>`_


### PR DESCRIPTION
The old link (http://forge.typo3.org/projects/extension-sf_register/issues) does not work anymore. I assume the correct way to look for known problems is the github issue-tracker.