### PR TITLE
Support for sr_freecap

### DIFF
--- a/Configuration/TypoScript/Common/constants.typoscript
+++ b/Configuration/TypoScript/Common/constants.typoscript
@@ -28,6 +28,6 @@ plugin.tx_sfregister.settings {
   # cat=sf_register.settings//10; type=int+; label=LLL:EXT:sf_register/Resources/Private/Language/locallang_ts.xlf:common.invitePid
   invitePid = 0
 
-  # cat=sf_register.settings//10; type=int+; label=LLL:EXT:sf_register/Resources/Private/Language/locallang_ts.xlf:common.resendPid
-  resendPid = 0
+  # cat=sf_register.settings//30; type=text; label= LLL:EXT:sf_register/Resources/Private/Language/locallang_ts.xlf:common.captchaId
+  captchaId = recaptcha
 }

--- a/Configuration/TypoScript/Common/constants.typoscript
+++ b/Configuration/TypoScript/Common/constants.typoscript
@@ -28,6 +28,9 @@ plugin.tx_sfregister.settings {
   # cat=sf_register.settings//10; type=int+; label=LLL:EXT:sf_register/Resources/Private/Language/locallang_ts.xlf:common.invitePid
   invitePid = 0
 
+  # cat=sf_register.settings//10; type=int+; label=LLL:EXT:sf_register/Resources/Private/Language/locallang_ts.xlf:common.resendPid
+  resendPid = 0
+
   # cat=sf_register.settings//30; type=text; label= LLL:EXT:sf_register/Resources/Private/Language/locallang_ts.xlf:common.captchaId
   captchaId = recaptcha
 }

--- a/Configuration/TypoScript/Common/setup.typoscript
+++ b/Configuration/TypoScript/Common/setup.typoscript
@@ -25,6 +25,7 @@ plugin.tx_sfregister.settings {
   editPid = {$plugin.tx_sfregister.settings.editPid}
   passwordPid = {$plugin.tx_sfregister.settings.passwordPid}
   invitePid = {$plugin.tx_sfregister.settings.invitePid}
+  resendPid = {$plugin.tx_sfregister.settings.resendPid}
 
   # comma separated list of words used in bad word validator
   badWordList = {$plugin.tx_sfregister.settings.badWordList}
@@ -96,6 +97,13 @@ plugin.tx_sfregister.settings {
   }
 
   validation.delete {
+  }
+
+  validation.resend {
+    email {
+      1 = "Evoweb.SfRegister:Required"
+      2 = "EmailAddress"
+    }
   }
 
   # integer usergroup set if no activation is needed

--- a/Configuration/TypoScript/Common/setup.typoscript
+++ b/Configuration/TypoScript/Common/setup.typoscript
@@ -25,7 +25,6 @@ plugin.tx_sfregister.settings {
   editPid = {$plugin.tx_sfregister.settings.editPid}
   passwordPid = {$plugin.tx_sfregister.settings.passwordPid}
   invitePid = {$plugin.tx_sfregister.settings.invitePid}
-  resendPid = {$plugin.tx_sfregister.settings.resendPid}
 
   # comma separated list of words used in bad word validator
   badWordList = {$plugin.tx_sfregister.settings.badWordList}
@@ -55,7 +54,7 @@ plugin.tx_sfregister.settings {
       2 = "Evoweb.SfRegister:IsTrue"
     }
     image = "Evoweb.SfRegister:ImageUpload"
-    captcha = "Evoweb.SfRegister:Captcha", options={"type": "jmrecaptcha"}
+    captcha = "Evoweb.SfRegister:Captcha", options={"type": "{$plugin.tx_sfregister.settings.captchaId}"}
   }
 
   validation.edit {
@@ -93,17 +92,10 @@ plugin.tx_sfregister.settings {
       1 = "Evoweb.SfRegister:Required"
       2 = "EmailAddress"
     }
-    captcha = "Evoweb.SfRegister:Captcha", options={"type": "jmrecaptcha"}
+    captcha = "Evoweb.SfRegister:Captcha", options={"type": "{$plugin.tx_sfregister.settings.captchaId}"}
   }
 
   validation.delete {
-  }
-
-  validation.resend {
-    email {
-      1 = "Evoweb.SfRegister:Required"
-      2 = "EmailAddress"
-    }
   }
 
   # integer usergroup set if no activation is needed

--- a/Configuration/TypoScript/Fields/setup.typoscript
+++ b/Configuration/TypoScript/Fields/setup.typoscript
@@ -112,11 +112,6 @@ plugin.tx_sfregister.settings.fields {
     20 = delete
   }
 
-  resendDefaultSelected {
-    10 = email
-    20 = resend
-  }
-
   configuration {
     username.partial = Textfield
 
@@ -262,7 +257,7 @@ plugin.tx_sfregister.settings.fields {
 
     captcha {
       partial = Captcha
-      type = recaptcha
+      type = {$plugin.tx_sfregister.settings.captchaId}
     }
 
     invitationEmail {
@@ -281,7 +276,5 @@ plugin.tx_sfregister.settings.fields {
     update.partial = Update
 
     delete.partial = Delete
-
-    resend.partial = Resend
   }
 }

--- a/Configuration/TypoScript/Fields/setup.typoscript
+++ b/Configuration/TypoScript/Fields/setup.typoscript
@@ -112,6 +112,11 @@ plugin.tx_sfregister.settings.fields {
     20 = delete
   }
 
+  resendDefaultSelected {
+    10 = email
+    20 = resend
+  }
+
   configuration {
     username.partial = Textfield
 
@@ -276,5 +281,7 @@ plugin.tx_sfregister.settings.fields {
     update.partial = Update
 
     delete.partial = Delete
+
+    resend.partial = Resend
   }
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -295,6 +295,9 @@
 				<source>Profilimage</source>
 				<target>Profilbild</target>
 			</trans-unit>
+			<trans-unit id="captcha">
+				<source>Verifizierungscode</source>
+			</trans-unit>
 			<trans-unit id="image_none">
 				<source>Profilimage not uploaded</source>
 				<target>Profilbild nicht hochgeladen</target>
@@ -347,10 +350,6 @@
 				<source>update</source>
 				<target>aktualisieren</target>
 			</trans-unit>
-			<trans-unit id="submit_resend">
-				<source>resend</source>
-				<target>senden</target>
-			</trans-unit>
 			<trans-unit id="submit_removeImage">
 				<source>remove</source>
 				<target>entfernen</target>
@@ -358,10 +357,6 @@
 			<trans-unit id="username">
 				<source>Username</source>
 				<target>Benutzername</target>
-			</trans-unit>
-			<trans-unit id="usernameOrEmail">
-				<source>Username or Email</source>
-				<target>Benutzername oder E-Mail</target>
 			</trans-unit>
 			<trans-unit id="pseudonym">
 				<source>Pseudonym</source>
@@ -382,10 +377,6 @@
 			<trans-unit id="password_saved">
 				<source>password saved</source>
 				<target>Passwort gespeichert</target>
-			</trans-unit>
-			<trans-unit id="resend_mail_sent">
-				<source>If your email address was found the confirmation mail was sent to you again.</source>
-				<target>Falls Ihre Mailadresse gefunden wurde, wurde die Bestätigungsmail erneut an Sie gesendet.</target>
 			</trans-unit>
 			<trans-unit id="account_not_found">
 				<source>The account you are trying to activate is unknow to the system.</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -350,6 +350,10 @@
 				<source>update</source>
 				<target>aktualisieren</target>
 			</trans-unit>
+			<trans-unit id="submit_resend">
+				<source>resend</source>
+				<target>senden</target>
+			</trans-unit>
 			<trans-unit id="submit_removeImage">
 				<source>remove</source>
 				<target>entfernen</target>
@@ -357,6 +361,10 @@
 			<trans-unit id="username">
 				<source>Username</source>
 				<target>Benutzername</target>
+			</trans-unit>
+			<trans-unit id="usernameOrEmail">
+				<source>Username or Email</source>
+				<target>Benutzername oder E-Mail</target>
 			</trans-unit>
 			<trans-unit id="pseudonym">
 				<source>Pseudonym</source>
@@ -377,6 +385,10 @@
 			<trans-unit id="password_saved">
 				<source>password saved</source>
 				<target>Passwort gespeichert</target>
+			</trans-unit>
+			<trans-unit id="resend_mail_sent">
+				<source>If your email address was found the confirmation mail was sent to you again.</source>
+				<target>Falls Ihre Mailadresse gefunden wurde, wurde die Bestätigungsmail erneut an Sie gesendet.</target>
 			</trans-unit>
 			<trans-unit id="account_not_found">
 				<source>The account you are trying to activate is unknow to the system.</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -258,11 +258,17 @@
 			<trans-unit id="submit_update">
 				<source>update</source>
 			</trans-unit>
+			<trans-unit id="submit_resend">
+				<source>resend</source>
+			</trans-unit>
 			<trans-unit id="submit_removeImage">
 				<source>remove</source>
 			</trans-unit>
 			<trans-unit id="username">
 				<source>Username</source>
+			</trans-unit>
+			<trans-unit id="usernameOrEmail">
+				<source>Username or Email</source>
 			</trans-unit>
 			<trans-unit id="pseudonym">
 				<source>Pseudonym</source>
@@ -278,6 +284,9 @@
 			</trans-unit>
 			<trans-unit id="password_saved">
 				<source>Password successfully updated</source>
+			</trans-unit>
+			<trans-unit id="resend_mail_sent">
+				<source>If your email address was found the confirmation mail was sent to you again.</source>
 			</trans-unit>
 			<trans-unit id="account_not_found">
 				<source>The account that you are trying to activate is unknown to the system.</source>
@@ -410,22 +419,22 @@
 			</trans-unit>
 
 			<trans-unit id="subjectAdminNotificationPostEditSave">
-				<source>User %2$s has edited informations on site %1$s</source>
+				<source>User %2$s has edited information on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectAdminNotificationPostEditConfirm">
-				<source>User %2$s has confirmed the change of informations on site %1$s</source>
+				<source>User %2$s has confirmed the change of information on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectAdminNotificationPostEditAccept">
-				<source>User %2$s change of informations was accepted on site %1$s</source>
+				<source>User %2$s change of information was accepted on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostEditSave">
 				<source>You %2$s changed your information on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostEditConfirm">
-				<source>Thank you %2$s for confirming the change of informations on site %1$s</source>
+				<source>Thank you %2$s for confirming the change of information on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostEditAccept">
-				<source>Your change of informations for account %2$s on site %1$s was accepted</source>
+				<source>Your change of information for account %2$s on site %1$s was accepted</source>
 			</trans-unit>
 
 			<trans-unit id="subjectAdminNotificationSendInvitation">
@@ -449,6 +458,13 @@
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostDeleteConfirm">
 				<source>Your confirmed to delete the account %2$s from %1$s</source>
+			</trans-unit>
+
+			<trans-unit id="subjectAdminNotificationPostReMail">
+				<source>User %2$s requested a resend of the activation key of the account from %1$s</source>
+			</trans-unit>
+			<trans-unit id="subjectUserNotificationPostReMail">
+				<source>Your requested a resend of the activation key of the account %2$s from %1$s</source>
 			</trans-unit>
 
 			<trans-unit id="email_admin_salutation">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -222,6 +222,9 @@
 			<trans-unit id="image">
 				<source>Profile image</source>
 			</trans-unit>
+			<trans-unit id="captcha">
+				<source>Verification code</source>
+			</trans-unit>
 			<trans-unit id="image_none">
 				<source>Profile image not uploaded</source>
 			</trans-unit>
@@ -255,17 +258,11 @@
 			<trans-unit id="submit_update">
 				<source>update</source>
 			</trans-unit>
-			<trans-unit id="submit_resend">
-				<source>resend</source>
-			</trans-unit>
 			<trans-unit id="submit_removeImage">
 				<source>remove</source>
 			</trans-unit>
 			<trans-unit id="username">
 				<source>Username</source>
-			</trans-unit>
-			<trans-unit id="usernameOrEmail">
-				<source>Username or Email</source>
 			</trans-unit>
 			<trans-unit id="pseudonym">
 				<source>Pseudonym</source>
@@ -281,9 +278,6 @@
 			</trans-unit>
 			<trans-unit id="password_saved">
 				<source>Password successfully updated</source>
-			</trans-unit>
-			<trans-unit id="resend_mail_sent">
-				<source>If your email address was found the confirmation mail was sent to you again.</source>
 			</trans-unit>
 			<trans-unit id="account_not_found">
 				<source>The account that you are trying to activate is unknown to the system.</source>
@@ -416,22 +410,22 @@
 			</trans-unit>
 
 			<trans-unit id="subjectAdminNotificationPostEditSave">
-				<source>User %2$s has edited information on site %1$s</source>
+				<source>User %2$s has edited informations on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectAdminNotificationPostEditConfirm">
-				<source>User %2$s has confirmed the change of information on site %1$s</source>
+				<source>User %2$s has confirmed the change of informations on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectAdminNotificationPostEditAccept">
-				<source>User %2$s change of information was accepted on site %1$s</source>
+				<source>User %2$s change of informations was accepted on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostEditSave">
 				<source>You %2$s changed your information on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostEditConfirm">
-				<source>Thank you %2$s for confirming the change of information on site %1$s</source>
+				<source>Thank you %2$s for confirming the change of informations on site %1$s</source>
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostEditAccept">
-				<source>Your change of information for account %2$s on site %1$s was accepted</source>
+				<source>Your change of informations for account %2$s on site %1$s was accepted</source>
 			</trans-unit>
 
 			<trans-unit id="subjectAdminNotificationSendInvitation">
@@ -455,13 +449,6 @@
 			</trans-unit>
 			<trans-unit id="subjectUserNotificationPostDeleteConfirm">
 				<source>Your confirmed to delete the account %2$s from %1$s</source>
-			</trans-unit>
-
-			<trans-unit id="subjectAdminNotificationPostReMail">
-				<source>User %2$s requested a resend of the activation key of the account from %1$s</source>
-			</trans-unit>
-			<trans-unit id="subjectUserNotificationPostReMail">
-				<source>Your requested a resend of the activation key of the account %2$s from %1$s</source>
 			</trans-unit>
 
 			<trans-unit id="email_admin_salutation">

--- a/Resources/Private/Language/locallang_ts.xlf
+++ b/Resources/Private/Language/locallang_ts.xlf
@@ -93,6 +93,12 @@
 			<trans-unit id="maximal.notifyUserPostDeleteConfirm">
 				<source>the user should get an email after an delete request was confirmed</source>
 			</trans-unit>
+			<trans-unit id="maximal.notifyAdminPostResendMail">
+				<source>the admin should get an email with the activation key for an awaiting registration</source>
+			</trans-unit>
+			<trans-unit id="maximal.notifyUserPostResendMail">
+				<source>the user should get an email with the activation key for an awaiting registration</source>
+			</trans-unit>
 
 			<trans-unit id="maximal.confirmEmailPostEdit">
 				<source>user needs to confirm the email change</source>
@@ -222,6 +228,10 @@
 			<trans-unit id="common.invitePid">
 				<source>Id of page with invite form</source>
 			</trans-unit>
+			<trans-unit id="common.resendPid">
+				<source>Id of page with resend form</source>
+			</trans-unit>
+
 			<trans-unit id="common.captchaId">
 				<source>Short name for the desired captcha extension: recaptcha, jmrecaptcha, srfreecap</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_ts.xlf
+++ b/Resources/Private/Language/locallang_ts.xlf
@@ -93,12 +93,6 @@
 			<trans-unit id="maximal.notifyUserPostDeleteConfirm">
 				<source>the user should get an email after an delete request was confirmed</source>
 			</trans-unit>
-			<trans-unit id="maximal.notifyAdminPostResendMail">
-				<source>the admin should get an email with the activation key for an awaiting registration</source>
-			</trans-unit>
-			<trans-unit id="maximal.notifyUserPostResendMail">
-				<source>the user should get an email with the activation key for an awaiting registration</source>
-			</trans-unit>
 
 			<trans-unit id="maximal.confirmEmailPostEdit">
 				<source>user needs to confirm the email change</source>
@@ -228,8 +222,8 @@
 			<trans-unit id="common.invitePid">
 				<source>Id of page with invite form</source>
 			</trans-unit>
-			<trans-unit id="common.resendPid">
-				<source>Id of page with resend form</source>
+			<trans-unit id="common.captchaId">
+				<source>Short name for the desired captcha extension: recaptcha, jmrecaptcha, srfreecap</source>
 			</trans-unit>
 
 			<trans-unit id="templateRootPath">

--- a/Resources/Private/Partials/CaptchaSrFreecap.html
+++ b/Resources/Private/Partials/CaptchaSrFreecap.html
@@ -6,6 +6,7 @@
 <div>
 	<f:if condition="{captcha.image}">
 		<f:then>
+			<f:render partial="Form/TextField" arguments="{user:user, fieldName:'captcha', options: options}" />
 			<f:format.raw>{captcha.image}</f:format.raw>
 			<f:format.raw>{captcha.notice}</f:format.raw>
 			<f:format.raw>{captcha.cantRead}</f:format.raw>


### PR DESCRIPTION
I suggest to introduce a typoscript constant 'captchaId' to specify e.g. 'recaptcha' or 'srfreecap' as captcha extension. 
In addition I inserted a textfield to partial CaptchaSrFreecap since I missed that an registration form. 
I tested this changes using sr_freecap, but not with other captcha extensions.  