### PR TITLE
Allow translate/modifying Mail Subjects

### DIFF
--- a/Classes/Services/Mail.php
+++ b/Classes/Services/Mail.php
@@ -232,9 +232,19 @@ class Mail implements \TYPO3\CMS\Core\SingletonInterface
 
     protected function getSubject(string $method, FrontendUserInterface $user): string
     {
-        $labelIndex = 'subject' . str_replace('send', '', $method);
 
-        return \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+        $labelIndex = 'subject' . str_replace('send', '', $method);
+        $subject    = null;
+
+        if (!empty($this->settings['translation']['subjects'])) {
+            $subject = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
+                $this->settings['translation']['subjects'] . ':' . $labelIndex,
+                null,
+                [$this->settings['sitename'], $user->getUsername()]
+            );
+        }
+
+        return $subject ?? \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate(
             $labelIndex,
             'SfRegister',
             [$this->settings['sitename'], $user->getUsername()]


### PR DESCRIPTION
Hello together, 

we have a requirement in one of our projects where we use the extension to customise the subject of the email according to the customer's request. 

As I did not see any possibility to do so, I implemented this solution. 

Regards