### PR TITLE
[BUGFIX] Change tca type of fe_users.status to select

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -144,7 +144,7 @@ call_user_func(function () {
         'status' => [
             'label' => $languageFile . 'fe_users.status',
             'config' => [
-                'type' => 'check',
+                'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
                     [$languageFile . 'fe_users.status.I.0', 0],


### PR DESCRIPTION
Hi, here is the PR for issue #166. fe_users.status has a wrong type in tca.

best regards
Frank