### PR TITLE
[BUGFIX] Cast value to integer before usage in multiplication

### DIFF
--- a/Classes/Services/File.php
+++ b/Classes/Services/File.php
@@ -126,6 +126,7 @@ class File implements SingletonInterface, LoggerAwareInterface
     protected function returnBytes($value): int
     {
         $last = strtolower(substr(trim($value), -1));
+        $value = (int)$value;
         switch ($last) {
             case 'g':
                 $value *= 1024 * 1024 * 1024;
@@ -140,7 +141,7 @@ class File implements SingletonInterface, LoggerAwareInterface
                 break;
         }
 
-        return (int)$value;
+        return $value;
     }
 
     public function getErrors(): array


### PR DESCRIPTION
There is an issue in Evoweb\SfRegister\Services\File::returnBytes(). While $value is a string like _100M_, the method will finaly multiply _100M * 1024 * 1024_ and ends up into a PHP warning _A non-numeric value encountered in /var/www/html/public/typo3conf/ext/sf_register/Classes/Services/File.php line 137_ in PHP ^8 and Typo3 11.5.4.

Converting the $value into integer before multiplying should solve this issue. With that, the integer conversion in the return part should be obsolete.

best regards
Frank