### PR TITLE
[BUGFIX] Do not call initializeObject from constructor

### DIFF
--- a/Classes/Domain/Model/FrontendUser.php
+++ b/Classes/Domain/Model/FrontendUser.php
@@ -317,11 +317,6 @@ class FrontendUser extends AbstractEntity implements FrontendUserInterface
     {
         $this->username = $username;
         $this->password = $password;
-        $this->initializeObject();
-    }
-
-    public function initializeObject()
-    {
         $this->image = $this->image ?? new ObjectStorage();
         $this->usergroup = $this->usergroup ?? new ObjectStorage();
         $this->moduleSysDmailCategory = new ObjectStorage();


### PR DESCRIPTION
initializeObject is for performing constructions tasks after the inject* method based injection of dependencies. Calling initializeObject on your own from constructor break this usage.

Resolves: #212