### PR TITLE
Partial name in CaptchaSrFreecap fixed

### DIFF
--- a/Resources/Private/Partials/CaptchaSrFreecap.html
+++ b/Resources/Private/Partials/CaptchaSrFreecap.html
@@ -6,7 +6,7 @@
 <div>
     <f:if condition="{captcha.image}">
         <f:then>
-            <f:render arguments="{user:user, fieldName: 'captcha', options: options}" partial="Form/TextField"/>
+            <f:render arguments="{user:user, fieldName: 'captcha', options: options}" partial="Form/Textfield"/>
             <f:format.raw>{captcha.image}</f:format.raw>
             <f:format.raw>{captcha.notice}</f:format.raw>
             <f:format.raw>{captcha.cantRead}</f:format.raw>


### PR DESCRIPTION
I found a small bug in 10.x version, that the name of partial in case of view for SrFreecap Captscha is wrong. Fix in the PR.