### PR TITLE
[BUGFIX] Fixes trim(): Argument #1 ($string) must be of type string, …

### DIFF
--- a/Classes/Updates/SwitchableControllerActionsPluginUpdater.php
+++ b/Classes/Updates/SwitchableControllerActionsPluginUpdater.php
@@ -101,6 +101,11 @@ class SwitchableControllerActionsPluginUpdater implements UpgradeWizardInterface
         foreach ($records as $record) {
             $flexFormData = GeneralUtility::xml2array($record['pi_flexform']);
             $flexForm = $this->flexFormService->convertFlexFormContentToArray($record['pi_flexform']);
+
+            if (!isset($flexForm['switchableControllerActions'])) {
+                continue;
+            }
+            
             $targetListType = $this->getTargetListType(
                 $record['list_type'],
                 $flexForm['switchableControllerActions']
@@ -169,7 +174,12 @@ class SwitchableControllerActionsPluginUpdater implements UpgradeWizardInterface
 
     protected function getAllowedSettingsFromFlexForm(string $listType): array
     {
-        $flexFormFile = $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'][$listType . ',list'];
+        $flexFormFile = $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'][$listType . ',list'] ?? null;
+
+        if ($flexFormFile === null) {
+            return [];
+        }
+        
         $flexFormContent = file_get_contents(GeneralUtility::getFileAbsFileName(substr(trim($flexFormFile), 5)));
         $flexFormData = GeneralUtility::xml2array($flexFormContent);
 


### PR DESCRIPTION
…null given

While executing the wizard I got the following error:
`trim(): Argument #1 ($string) must be of type string, null given.`

The fix prevents the wizard from throwing the error and lets it run through.

![grafik](https://github.com/evoWeb/sf_register/assets/564393/eac241f8-f51c-4240-baf6-d91042208aaa)
