### PR TITLE
[BUGFIX] Deletes User without confirmation mail

### DIFF
--- a/Classes/Controller/FeuserDeleteController.php
+++ b/Classes/Controller/FeuserDeleteController.php
@@ -89,14 +89,16 @@ class FeuserDeleteController extends FeuserController
             $user = $this->userRepository->findByEmail($user->getEmail());
         }
 
-        if ($user instanceof FrontendUser && $user->getUid()) {
+        if ($this->settings['notifyUser']['deleteSave'] == 0) {
+            $this->userRepository->remove($user);
+            $this->persistAll();
+        } elseif ($user instanceof FrontendUser && $user->getUid()) {
             $user = $this->sendEmails($user, __FUNCTION__);
+            $this->view->assign('user', $user);
         } else {
             $this->view->assign('userNotFound', true);
         }
-
-        $this->view->assign('user', $user);
-
+        
         return new HtmlResponse($this->view->render());
     }
 


### PR DESCRIPTION
This is how I would address the problem with not deleting the user when the confirmation email is turned off for this.