### PR TITLE
[BUGFIX] Use correct option for optionLabelField in f:form.countrySelect

### DIFF
--- a/Resources/Private/Partials/Form/CountrySelect.html
+++ b/Resources/Private/Partials/Form/CountrySelect.html
@@ -10,7 +10,7 @@
     <f:form.countrySelect
         property="{fieldName}"
         id="sfrCountry"
-        optionLabelField="localizedNameLabel"
+        optionLabelField="localizedName"
         alternativeLanguage="en"
         sortByOptionLabel="true"
         prependOptionLabel="{f:translate(id: 'please_select')}"

--- a/Resources/Private/Partials/Form/CountrySelect.html
+++ b/Resources/Private/Partials/Form/CountrySelect.html
@@ -11,7 +11,6 @@
         property="{fieldName}"
         id="sfrCountry"
         optionLabelField="localizedName"
-        alternativeLanguage="en"
         sortByOptionLabel="true"
         prependOptionLabel="{f:translate(id: 'please_select')}"
         prependOptionValue=""


### PR DESCRIPTION
'localizedNameLabel' is not allowed as a value in optionLabelField. Replacing it with localizedName

Also removed alternativeLanguage since it would force the countries to always be displayed in english. 

See: https://docs.typo3.org/other/typo3/view-helper-reference/12.4/en-us/Global/Form/CountrySelect.html#viewhelper-argument-typo3-cms-fluid-viewhelpers-form-countryselectviewhelper-optionlabelfield