### PR TITLE
Improve mail formatting for HTML and Plain parts

### DIFF
--- a/Classes/Services/Mail.php
+++ b/Classes/Services/Mail.php
@@ -328,7 +328,8 @@ class Mail implements SingletonInterface
             templateRootPaths: $this->frameworkConfiguration['view']['templateRootPaths'],
             partialRootPaths: $this->frameworkConfiguration['view']['partialRootPaths'],
             layoutRootPaths: $this->frameworkConfiguration['view']['layoutRootPaths'],
-            request: $request
+            request: $request,
+            format: $format
         );
         return $this->viewFactory->create($viewFactoryData);
     }

--- a/Resources/Private/Templates/Email/InvitationToRegister.html
+++ b/Resources/Private/Templates/Email/InvitationToRegister.html
@@ -5,10 +5,10 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_invitee_invitation_message" arguments="{0: user.invitationEmail, 1: settings.sitename}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_invitee_invitation_message" arguments="{0: user.invitationEmail, 1: settings.sitename}"/></f:format.raw><br>
+	<br>
 	<register:link.action pageUid="{settings.createPid}" arguments="{user: {email: user.invitationEmail, byInvitation: 1}}" action="form" controller="FeuserCreate" absolute="true">
 		<f:translate id="email_invitee_register_link"/>
 	</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyAdminCreateAccept.html
+++ b/Resources/Private/Templates/Email/NotifyAdminCreateAccept.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_accepted" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminCreateConfirm.html
+++ b/Resources/Private/Templates/Email/NotifyAdminCreateConfirm.html
@@ -5,14 +5,14 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_admin_account_confirmed" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_admin_account_confirmed" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<f:if condition="{settings.acceptEmailPostConfirm}">
 		<register:link.action arguments="{user: user.uid}" action="accept" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_accept_link"/>
-		</register:link.action>
+		</register:link.action><br>
 		<register:link.action arguments="{user: user.uid}" action="decline" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_decline_link"/>
 		</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyAdminCreateDecline.html
+++ b/Resources/Private/Templates/Email/NotifyAdminCreateDecline.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_declined" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminCreateRefuse.html
+++ b/Resources/Private/Templates/Email/NotifyAdminCreateRefuse.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_refused" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminCreateSave.html
+++ b/Resources/Private/Templates/Email/NotifyAdminCreateSave.html
@@ -5,14 +5,14 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_admin_account_saved" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_admin_account_saved" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<f:if condition="{settings.acceptEmailPostCreate}">
 		<register:link.action arguments="{user: user.uid}" action="accept" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_accept_link"/>
-		</register:link.action>
+		</register:link.action><br>
 		<register:link.action arguments="{user: user.uid}" action="decline" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_decline_link"/>
 		</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyAdminDeleteConfirm.html
+++ b/Resources/Private/Templates/Email/NotifyAdminDeleteConfirm.html
@@ -4,8 +4,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_deleted" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminDeleteSave.html
+++ b/Resources/Private/Templates/Email/NotifyAdminDeleteSave.html
@@ -4,8 +4,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_delete" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminDeleteSendLink.html
+++ b/Resources/Private/Templates/Email/NotifyAdminDeleteSendLink.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_sendlink" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminEditAccept.html
+++ b/Resources/Private/Templates/Email/NotifyAdminEditAccept.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_account_available" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminEditConfirm.html
+++ b/Resources/Private/Templates/Email/NotifyAdminEditConfirm.html
@@ -5,10 +5,10 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_admin_account_activated" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_admin_account_activated" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<register:link.action arguments="{user: user.uid}" action="accept" controller="FeuserEdit" absolute="true">
 		<f:translate id="email_admin_activate_link"/>
 	</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyAdminEditSave.html
+++ b/Resources/Private/Templates/Email/NotifyAdminEditSave.html
@@ -5,10 +5,10 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_admin_activate_message" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_admin_activate_message" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<register:link.action arguments="{user: user.uid}" action="accept" controller="FeuserEdit" absolute="true">
 		<f:translate id="email_admin_activate_link"/>
 	</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyAdminInviteInvite.html
+++ b/Resources/Private/Templates/Email/NotifyAdminInviteInvite.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_admin_invitation_message" arguments="{0: user.username, 1: user.invitationEmail}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyAdminResendMail.html
+++ b/Resources/Private/Templates/Email/NotifyAdminResendMail.html
@@ -5,14 +5,14 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_admin_account_saved" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_admin_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_admin_account_saved" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<f:if condition="{settings.acceptEmailPostCreate}">
 		<register:link.action arguments="{user: user.uid}" action="accept" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_accept_link"/>
-		</register:link.action>
+		</register:link.action><br>
 		<register:link.action arguments="{user: user.uid}" action="decline" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_decline_link"/>
 		</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyUserCreateAccept.html
+++ b/Resources/Private/Templates/Email/NotifyUserCreateAccept.html
@@ -5,14 +5,14 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_user_account_accepted" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_user_account_accepted" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<f:if condition="{settings.confirmEmailPostAccept}">
 		<register:link.action arguments="{user: user.uid}" action="confirm" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_confirm_link"/>
-		</register:link.action>
+		</register:link.action><br>
 		<register:link.action arguments="{user: user.uid}" action="refuse" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_refuse_link"/>
 		</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyUserCreateConfirm.html
+++ b/Resources/Private/Templates/Email/NotifyUserCreateConfirm.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_user_account_confirmed" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserCreateDecline.html
+++ b/Resources/Private/Templates/Email/NotifyUserCreateDecline.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_user_account_declined" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserCreateRefuse.html
+++ b/Resources/Private/Templates/Email/NotifyUserCreateRefuse.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_user_account_refused" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserCreateSave.html
+++ b/Resources/Private/Templates/Email/NotifyUserCreateSave.html
@@ -5,14 +5,14 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_user_account_saved" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_user_account_saved" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<f:if condition="{settings.confirmEmailPostCreate}">
 		<register:link.action arguments="{user: user.uid}" action="confirm" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_confirm_link"/>
-		</register:link.action>
+		</register:link.action><br>
 		<register:link.action arguments="{user: user.uid}" action="refuse" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_refuse_link"/>
 		</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyUserDeleteConfirm.html
+++ b/Resources/Private/Templates/Email/NotifyUserDeleteConfirm.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_user_account_deleted" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserDeleteSave.html
+++ b/Resources/Private/Templates/Email/NotifyUserDeleteSave.html
@@ -5,10 +5,10 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_user_account_delete" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_user_account_delete" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<register:link.action arguments="{user: user.uid}" action="confirm" controller="FeuserDelete" absolute="true">
 		<f:translate id="email_user_delete_link"/>
 	</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyUserDeleteSendLink.html
+++ b/Resources/Private/Templates/Email/NotifyUserDeleteSendLink.html
@@ -5,10 +5,10 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_email_account_sendlink" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_email_account_sendlink" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<register:link.action arguments="{user: user.uid}" action="form" controller="FeuserDelete" absolute="true">
 		<f:translate id="email_email_account_sendlink_link"/>
 	</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyUserEditAccept.html
+++ b/Resources/Private/Templates/Email/NotifyUserEditAccept.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/>,</f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/>,</f:format.raw><br>
+	<br>
 	<f:format.raw><f:translate id="email_user_account_available" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserEditConfirm.html
+++ b/Resources/Private/Templates/Email/NotifyUserEditConfirm.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_user_account_activated" arguments="{0: user.username}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserEditSave.html
+++ b/Resources/Private/Templates/Email/NotifyUserEditSave.html
@@ -5,10 +5,10 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_user_activate_message" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_user_activate_message" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<register:link.action arguments="{user: user.uid}" action="confirm" controller="FeuserEdit" absolute="true">
 		<f:translate id="email_user_activate_link"/>
 	</register:link.action>

--- a/Resources/Private/Templates/Email/NotifyUserInviteInvite.html
+++ b/Resources/Private/Templates/Email/NotifyUserInviteInvite.html
@@ -3,8 +3,8 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
 	<f:format.raw><f:translate id="email_user_invitation_message" arguments="{0: user.invitationEmail, 1: settings.sitename}"/></f:format.raw>
 </f:section>
 

--- a/Resources/Private/Templates/Email/NotifyUserResendMail.html
+++ b/Resources/Private/Templates/Email/NotifyUserResendMail.html
@@ -5,14 +5,14 @@
 <f:layout name="Email" />
 
 <f:section name="Main">
-	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,
-
-	<f:format.raw><f:translate id="email_user_account_saved" arguments="{0: user.username}"/></f:format.raw>
-
+	<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,<br>
+	<br>
+	<f:format.raw><f:translate id="email_user_account_saved" arguments="{0: user.username}"/></f:format.raw><br>
+	<br>
 	<f:if condition="{settings.confirmEmailPostCreate}">
 		<register:link.action pageUid="{settings.createPid}" arguments="{user: user.uid}" action="confirm" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_confirm_link"/>
-		</register:link.action>
+		</register:link.action><br>
 		<register:link.action pageUid="{settings.createPid}" arguments="{user: user.uid}" action="refuse" controller="FeuserCreate" absolute="true">
 			<f:translate id="email_user_refuse_link"/>
 		</register:link.action>


### PR DESCRIPTION
I don't exactly know, if I should name this a bugfix, a task or even a new feature 😉 

This pull requests consists of two changes:

## Correctly pass `$format`  to `ViewFactoryData`

On the one hand, this allows the integrator to define a separate Fluid template in text/plain format for each mail. 

Example: `NotifyUserCreateSave.txt`

```{namespace register=Evoweb\SfRegister\ViewHelpers}
<f:format.raw><f:translate id="email_user_salutation"/></f:format.raw>,

<f:format.raw><f:translate id="email_user_account_saved" arguments="{0: user.username}"/></f:format.raw>
```

And on the other hand - if such a template file, does not exist - TYPO3 converts the HTML automatically into plain text and even splits links into link text and URLs (see screenshots below)

## Define line breaks in mail templates

The fact, there were no `<br>` at all in the mail templates, resulted in unformatted single text lines in HTML view. In combination with the format fix and TYPO3's auto formatting, there is no need to skip the `<br>`  in the templates.

## Summary / Comparsion

### Before

| HTML | Plain |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/38287d33-816c-4312-a6e3-61e4bcef931c) | ![image](https://github.com/user-attachments/assets/4f516040-c2bf-4290-8228-1181af60046d) |
| no line breaks, just one single line of text | ugly indentations, links are wrapped in `<a>` tags |

### After

| HTML | Plain |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/90dafbc6-5d5a-4c52-b966-4866d92ea0b4) | ![image](https://github.com/user-attachments/assets/22d53cc6-94f2-431e-a35d-0fc4f2697892) |
| improved readabilty | proper indentations, link text and URL can be unterstood |