### PR TITLE
[BUGFIX] Only autofill resend email if user is logged in

### DIFF
--- a/Classes/Controller/FeuserResendController.php
+++ b/Classes/Controller/FeuserResendController.php
@@ -54,7 +54,9 @@ class FeuserResendController extends FeuserController
             $email = new Email();
             try {
                 $user = $this->frontendUserService->getLoggedInUser();
-                $email->setEmail($user->getEmail());
+                if ($user !== null) {
+                    $email->setEmail($user->getEmail());
+                }
             } catch (\Exception) {
             }
         }


### PR DESCRIPTION
The FeuserResendController tries to autofill the email of the currently logged in user. However, if no user exists, this fails hard because `$user` is `null`. The `try catch` block doesn't help here, as it's a PHP error ("undefined method on null") and not an exception.