### PR TITLE
Fix: Check disabled argument before use in view helpers

### DIFF
--- a/Classes/ViewHelpers/Form/SelectStaticCountryZonesViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectStaticCountryZonesViewHelper.php
@@ -68,7 +68,7 @@ class SelectStaticCountryZonesViewHelper extends AbstractSelectViewHelper
         try {
             $options = $this->countryZonesRepository->findAllByIso2($this->arguments['parent'])->fetchAllAssociative();
 
-            if ($this->arguments['disabled']) {
+            if (isset($this->arguments['disabled']) && $this->arguments['disabled']) {
                 $value = (array)$this->getSelectedValue();
 
                 $options = array_filter(

--- a/Classes/ViewHelpers/Form/SelectStaticLanguageViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectStaticLanguageViewHelper.php
@@ -75,7 +75,7 @@ class SelectStaticLanguageViewHelper extends AbstractSelectViewHelper
         }
         $options = $options->toArray();
 
-        if ($this->arguments['disabled']) {
+        if (isset($this->arguments['disabled']) && $this->arguments['disabled']) {
             $value = (array)$this->getSelectedValue();
 
             $options = array_filter(


### PR DESCRIPTION
This fixes a bug where the disabled argument was used without verifying its existence.

### Changes

Added existence check for disabled argument.

Applied to `SelectStaticCountryZones` and `SelectStaticLanguage` helpers.

### Why

Prevents runtime errors and improves robustness of the helpers.