### PR TITLE
Fix cleanup command and add restricted users to cleanup process

### DIFF
--- a/Classes/Command/CleanupCommand.php
+++ b/Classes/Command/CleanupCommand.php
@@ -179,8 +179,8 @@ class CleanupCommand extends Command
             ->getConnection()
             ->delete($table, [
                 'uid_foreign' => $user['uid'],
-                'tablenames' => $user['fe_users'],
-                'fieldname' => $user['image'],
+                'tablenames' => 'fe_users',
+                'fieldname' => 'image',
             ]);
     }
 

--- a/Classes/Command/CleanupCommand.php
+++ b/Classes/Command/CleanupCommand.php
@@ -106,6 +106,7 @@ class CleanupCommand extends Command
     {
         $table = 'fe_users';
         $queryBuilder = $this->getQueryBuilderForTable($table);
+        $queryBuilder->resetRestrictions();
 
         $result = $queryBuilder
             ->select('uid')


### PR DESCRIPTION
Found an issue with the cleanup command. The tables for the references cleanup aren't set correctly.
Beside that, for us it's a use-case to cleanup hidden users, as they get an "inactive" group upon registration which is switched after confirmation. So we also want to include hidden users. Should this go into the extension or is this behavior not wanted?