### PR TITLE
[BUGFIX] Adjust ext_emconf description for composer title in v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
   resources:
     name: Resources tests
     runs-on: ubuntu-latest
+    env:
+      CONTAINER_RUNTIME: runc
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "evoweb/sf-register",
 	"type": "typo3-cms-extension",
-	"description": "Frontend User Registration",
+	"description": "Frontend User Registration - Offers the possibility to maintain the fe_user data in frontend by the user self.",
 	"homepage": "https://www.evoweb.de",
 	"license": [
 		"GPL-2.0-or-later"


### PR DESCRIPTION
Since TYPO3 v14, the extension title is populated from `composer.json`. The Extension Manager validates that the composer description equals `$extensionConfig['title'] . ' - ' . $extensionConfig['description']`.

The new required format has not yet been incorporated into the `composer.json` file, which resulted in the `EXTENSION_TITLE_MISSING` error being reported.

This change adds the missing description and restores consistency between `ext_emconf.php` and `composer.json`.

References: [Breaking: #108304 - Populate extension title from composer.json](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108304-PopulateExtensionTitleFromComposerJson.html)