### PR TITLE
[BUGFIX] Cleanup command: actually delete disabled unconfirmed users

### DIFF
--- a/Classes/Command/CleanupCommand.php
+++ b/Classes/Command/CleanupCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException;
 use TYPO3\CMS\Core\Resource\Exception\FileOperationErrorException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFileAccessPermissionsException;
@@ -108,7 +109,7 @@ class CleanupCommand extends Command
     {
         $table = 'fe_users';
         $queryBuilder = $this->getQueryBuilderForTable($table);
-        $queryBuilder->resetRestrictions();
+        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
 
         $result = $queryBuilder
             ->select('uid')


### PR DESCRIPTION
Fixes #315 for the develop line.

`findInOutdatedTemporaryUsers()` queries fe_users through the default restriction container, whose `HiddenRestriction` forces `disable = 0`. Accounts that never confirmed the double opt-in are `disable = 1`, so they were never matched and the command deleted nothing.

The existing `resetRestrictions()` call does not fix this: it resets to a fresh `DefaultRestrictionContainer`, which re-adds the `HiddenRestriction`, so it is a no-op. This replaces it with `getRestrictions()->removeByType(HiddenRestriction::class)`, removing only the `HiddenRestriction` and keeping the `DeletedRestriction` (the command hard-deletes) and the time restrictions.
