### PR TITLE
[BUGFIX] Cleanup command: actually delete disabled unconfirmed users

### DIFF
--- a/Classes/Command/CleanupCommand.php
+++ b/Classes/Command/CleanupCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException;
 use TYPO3\CMS\Core\Resource\Exception\FileOperationErrorException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFileAccessPermissionsException;
@@ -105,6 +106,7 @@ class CleanupCommand extends Command
     {
         $table = 'fe_users';
         $queryBuilder = $this->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
 
         $result = $queryBuilder
             ->select('uid')
@@ -178,8 +180,8 @@ class CleanupCommand extends Command
             ->getConnection()
             ->delete($table, [
                 'uid_foreign' => $user['uid'],
-                'tablenames' => $user['fe_users'],
-                'fieldname' => $user['image'],
+                'tablenames' => 'fe_users',
+                'fieldname' => 'image',
             ]);
     }
 


### PR DESCRIPTION
Fixes #315 for this maintained line.

`findInOutdatedTemporaryUsers()` queries fe_users through the default restriction container, whose `HiddenRestriction` forces `disable = 0`. Accounts that never confirmed the double opt-in are `disable = 1`, so they were never matched and the command deleted nothing.

This adds `getRestrictions()->removeByType(HiddenRestriction::class)`, removing only the `HiddenRestriction` and keeping the `DeletedRestriction` (the command hard-deletes) and the time restrictions. This branch never received 466c033, so it also ports the orphan-image reference fix (the delete read non-existent `$user['fe_users']` / `$user['image']` keys from a row that only contains `uid`).

Note: on develop/14.x the same area was addressed by `resetRestrictions()`, which is a no-op (see #315); the working fix belongs on this branch too.
